### PR TITLE
Add exception handling around YAML loading of rule files

### DIFF
--- a/lofp/loader.py
+++ b/lofp/loader.py
@@ -39,13 +39,18 @@ class Loader:
 
     def from_path(self, path: Path) -> Optional[RuleTypes]:
         """Load a single file."""
-        if path.suffix == '.json':
-            contents = json.loads(path.read_text())
-        elif path.suffix == '.toml':
-            contents = pytoml.loads(path.read_text())
-        elif path.suffix in ('.yaml', '.yml'):
-            contents = yaml.safe_load(path.read_text())
-        else:
+        raw = path.read_text()
+        try:
+            if path.suffix == '.json':
+                contents = json.loads(raw)
+            elif path.suffix == '.toml':
+                contents = pytoml.loads(raw)
+            elif path.suffix in ('.yaml', '.yml'):
+                contents = yaml.safe_load(raw)
+            else:
+                return
+        except yaml.YAMLError as e:
+            print(f'error loading: {path} - {e}:\n{raw}')
             return
 
         relative_path = self.relative_to_repo(path)


### PR DESCRIPTION
YAML loading errors are unhandled when loading rule files. This wraps the load to print the error and bypass, to continue processing.

### Details

A potential bug (https://github.com/splunk/security_content/issues/3098) in a few rule files was causing YAML `ScannerError`s, leading to a failure of the [build](https://github.com/brokensound77/LoFP/actions/runs/10517690623/job/29142270785#step:10:108).